### PR TITLE
Don't add nil errors to the error stack

### DIFF
--- a/errhandling/stack.go
+++ b/errhandling/stack.go
@@ -9,7 +9,9 @@ func NewStack() *Stack {
 }
 
 func (s *Stack) Add(error error) {
-	s.errors = append(s.errors, error)
+	if error != nil {
+		s.errors = append(s.errors, error)
+	}
 }
 
 func (s *Stack) Empty() bool {


### PR DESCRIPTION
I'm not entirely sure how the errhandling code ever worked as written.
Using the bundled minecraft-rcon client code I was not able to
successfully send commands to a server.

What I observed was that the `errs.Add()` calls in client.go
createPayloadFromPacket were all running successfull (with nil error
values returned) but those nil values were being added to the error
stack.

This caused `errs.Empty()` to return false, because `len()` on the stack
returns 3 for the value `errors:[<nil> <nil> <nil>]`.

I revised the `stack.Add()` function so that it declines to add a nil
error to the stack.  An alternative approach would be for
`Stack.Empty()` to walk the stack and ignore nil values, but this
approach seemed simpler.